### PR TITLE
Add support for MacOS (darwin)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOMOBILE_PATH=~/go/bin/gomobile
 wasm: Makefile
 	GOOS=js GOARCH=wasm go build -v -o $(TARGET).wasm -ldflags="-s -w"
 
-linux: Makefile
+linux darwin: Makefile
 	go build -v -o $(TARGET) -ldflags="-s -w"
 
 windows: Makefile

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 // https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md
 // $ go mod init oddstream.games/gosol

--- a/sol/baize_darwin.go
+++ b/sol/baize_darwin.go
@@ -1,0 +1,16 @@
+package sol
+
+import (
+	"log"
+	"os/exec"
+)
+
+func (b *Baize) Wikipedia() {
+	var cmd *exec.Cmd = exec.Command("open", b.script.Info().wikipedia)
+	if cmd != nil {
+		err := cmd.Start()
+		if err != nil {
+			log.Println(err)
+		}
+	}
+}

--- a/sol/json.go
+++ b/sol/json.go
@@ -1,4 +1,4 @@
-//go:build linux || windows || android
+//go:build linux || windows || android || darwin
 
 package sol
 


### PR DESCRIPTION
MacOS works out of the box, it only needs to be added to the list of supported builds.
